### PR TITLE
Wire in watching bundleDeployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: run
-run: docker-build kind-cluster kind-load install deploy wait ## Build the operator-controller then deploy it into a new kind cluster.
+run: manifests generate fmt vet ## Run a controller from your host.
+ 	go run ./main.go 
 
 .PHONY: wait
 wait:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,13 +8,29 @@ rules:
 - apiGroups:
   - core.rukpak.io
   resources:
-  - bundledeployments
+  - deployments
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - operators.operatorframework.io


### PR DESCRIPTION
Wire in setting watches to bundleDeployment. This way when the operator object is deleted the bundleDeployment is updated too. Its a happy case wherein the bundleDeployment is owned by single operator object. 